### PR TITLE
docs: 将配置文件和文档翻译成英文

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,109 +1,109 @@
-## ================================ 目录 ================================
+## ================================ Directories ================================
 
-# 数据目录, 用于存放日志/数据库/文件等
+# Data directory, used for storing logs/databases/files etc.
 DATA_DIR=/data
-# docker仓库的目录, 不建议在compose文件中引用docker仓库的绝对路径, 建议使用configs替代: https://docs.docker.com/reference/compose-file/configs/
+# Docker repository directory, not recommended to reference absolute path of docker repository in compose files, recommended to use configs instead: https://docs.docker.com/reference/compose-file/configs/
 DOCKER_DIR=/home/docker
-# 实际配置项目配置目录
+# Actual project configuration directory
 DOCKER_COMPOSE_DIR=/home/docker-compose
-# bus前端文件复写目录, 该目录中的文件会在compose被up时被复制到bus前端目录, 通常可以复写如下文件:
-# - _app.config.js: 前端配置文件
+# Bus frontend file override directory, files in this directory will be copied to the bus frontend directory when compose is up, commonly used to override the following files:
+# - _app.config.js: Frontend configuration file
 BUS_WEB_OVERRIDE_DIR=${DOCKER_COMPOSE_DIR}/bus-override
-# track前端文件复写目录, 该目录中的文件会在compose被up时被复制到track前端目录, 通常可以复写如下文件:
-# - _app.config.js: 前端配置文件
-# - index-seo.html: 交给爬虫(搜索引擎/Line网页摘要等)读取的静态页面
-# - favicon.ico: ico图标
-# - favicon.png: png图标
-# - logo.png: 大图标
+# Track frontend file override directory, files in this directory will be copied to the track frontend directory when compose is up, commonly used to override the following files:
+# - _app.config.js: Frontend configuration file
+# - index-seo.html: Static page for crawlers (search engines/Line web summaries etc.)
+# - favicon.ico: ico icon
+# - favicon.png: png icon
+# - logo.png: large icon
 TRACK_WEB_OVERRIDE_DIR=${DOCKER_COMPOSE_DIR}/track-override
-# TOKEN目录的绝对路径, 包含以下文件, 最新版服务器已经支持自动生成/下载这些文件:
-# - access/ras_key|ras_key.pub: 访问密钥的公私钥对
-# - refresh/ras_key|ras_key.pub: 刷新密钥的公私钥对
-# - ip2region.xdb: ip到区域的映射数据, 手动下载连接: https://raw.githubusercontent.com/lionsoul2014/ip2region/master/data/ip2region.xdb
+# Absolute path of TOKEN directory, includes the following files, latest server versions support automatic generation/download of these files:
+# - access/ras_key|ras_key.pub: Public/private key pair for access key
+# - refresh/ras_key|ras_key.pub: Public/private key pair for refresh key
+# - ip2region.xdb: IP to region mapping data, manual download link: https://raw.githubusercontent.com/lionsoul2014/ip2region/master/data/ip2region.xdb
 MAINTAIN_TOKEN_DIR=${DOCKER_COMPOSE_DIR}/token
-# jtt808可选功能目录, 可选包含的文件如下, 下载方式详见: https://github.com/TranscodeGroup/docker/blob/master/jtt808/README.md
-# - ffmpeg, ffprobe: FFmpeg的bin文件
-# - ifv2mp4/: 通力ifv转mp4工具目录
+# jtt808 optional feature directory, optionally contains the following files, download details: https://github.com/TranscodeGroup/docker/blob/master/jtt808/README.md
+# - ffmpeg, ffprobe: FFmpeg bin files
+# - ifv2mp4/: Tongli ifv to mp4 tool directory
 JTT808_OPT_DIR=${DOCKER_COMPOSE_DIR}/opt
 
-## ================================ 服务器信息 ================================
+## ================================ Server Information ================================
 
-# 必填, 当前服务器公网IP, jtt808/video等服务不设置IP的时候,默认会读取这个
+# Required, current server public IP, jtt808/video and other services will read this by default when IP is not set
 SERVER_IP_PUBLIC='' # 58.82.168.181
 
-# 当前服务器内网IP, 目前没有人使用, 可以不填
-# JTT808_HOST/MYSQL_HOST等变量, 单机部署可以直接使用别名(eg: jtt808)，内网多服务器部署推荐内网IP, 公网部署使用公网IP
+# Current server internal IP, currently not used by anyone, can be left blank
+# Variables like JTT808_HOST/MYSQL_HOST etc., for standalone deployment can use aliases directly (eg: jtt808), for internal multi-server deployment recommend internal IP, for public deployment use public IP
 SERVER_IP_INTERNAL=''
 
-# 必填, 服务器域名, 若没有域名, 则填写公网IP
+# Required, server domain name, if no domain name, fill in public IP
 SERVER_HOSTNAME='' # livedvr.tripsdd.com
 
-# 必填, 证书文件的绝对路径, 排除.crt/.key后缀, nginx实际读取的是 ${SSL_CERTIFICATE}.crt 和 ${SSL_CERTIFICATE}.key 两个文件
-# 如果使用http, 或者使用https但暂时没有申请到证书, 可以设置成内置的假证书: /home/docker/nginx/ssl/placeholder
-# 若使用crotbot自动申请证书, 需要先单独启动一次(docker compose up crotbot), 申请到的证书路径会在日志中打印, 然后将它添加到变量中, 一般为: /data/certbot/live/${SERVER_HOSTNAME}/certificate, 
+# Required, absolute path of certificate file, excluding .crt/.key suffix, nginx actually reads ${SSL_CERTIFICATE}.crt and ${SSL_CERTIFICATE}.key files
+# If using http, or using https but haven't obtained certificate yet, can set to built-in fake certificate: /home/docker/nginx/ssl/placeholder
+# If using certbot to automatically apply for certificate, need to start separately once first (docker compose up certbot), the obtained certificate path will be printed in logs, then add it to this variable, usually: /data/certbot/live/${SERVER_HOSTNAME}/certificate,
 SSL_CERTIFICATE='' # /home/docker/nginx/ssl/placeholder
 
-# bus和track部署在同一台服务器上时, 需要通过域名区分两者
+# When bus and track are deployed on the same server, need to distinguish them by domain name
 BUS_HOSTNAME=${SERVER_HOSTNAME}
 BUS_SSL_CERTIFICATE=${SSL_CERTIFICATE}
 TRACK_HOSTNAME=${SERVER_HOSTNAME}
 TRACK_SSL_CERTIFICATE=${SSL_CERTIFICATE}
 
-## 前端配置
+## Frontend Configuration
 WEB_PORT_HTTP=80
 WEB_PORT_HTTPS=443
-# 前端的公网URL
-# jtt808和maintain分开部署时, 必须填写这个变量
+# Frontend public URL
+# This variable must be filled when jtt808 and maintain are deployed separately
 WEB_BASE_URL='' # https://livedvr.tripsdd.com
 
-# certbot的配置
-# 注意: 修改这些配置之后, 必须强制重建(docker compose up --force-recreate certbot), 才会生效
+# Certbot configuration
+# Note: After modifying these configurations, must force recreate (docker compose up --force-recreate certbot) to take effect
 #
-# DNS解析的提供商, 常用的提供商如下:
+# DNS resolution provider, commonly used providers:
 # - dnspod: https://console.dnspod.cn/account/token/token
 # - cloudflare: https://go-acme.github.io/lego/dns/cloudflare/
 # - tencentcloud: https://console.cloud.tencent.com/cam/capi
 CERTBOT_DNS_PROVIDER='dnspod'
-CERTBOT_DNS_API_KEY='' # 必填
-# tencentcloud还需要额外设置这个变量
+CERTBOT_DNS_API_KEY='' # Required
+# tencentcloud also needs to set this variable additionally
 CERTBOT_TENCENTCLOUD_SECRET_ID=''
-# 接收证书过期提醒的email
+# Email to receive certificate expiration reminders
 CERTBOT_EMAIL='transcodegroupdeveloper@gmail.com'
 
 ## ================================ Services ================================
 
-## 视频服务器
-# 必填, 视频公网IP, APP客户端和设备连接
+## Video Server
+# Required, video public IP, for APP client and device connections
 VIDEO_IP=${SERVER_IP_PUBLIC}
-# 必填
+# Required
 VIDEO_HOSTNAME=${SERVER_HOSTNAME} # livedvr.tripsdd.com
-# 必填
+# Required
 VIDEO_SSL_CERTIFICATE=${SSL_CERTIFICATE} # /home/docker/video-nginx/ssl/livedvr_tripsdd_com
 
-# 终端-实时直播端口
+# Terminal - Real-time live streaming port
 VIDEO_PORT_LIVE=9000
-# 终端-录像回放端口
+# Terminal - Recording playback port
 VIDEO_PORT_RECORD=9001
-# 终端-对讲
+# Terminal - Intercom
 VIDEO_PORT_TALK=9002
-# 终端-终端监听
+# Terminal - Terminal monitoring
 VIDEO_PORT_MONITOR=9003
-# rtmp端口(rtp和app使用)
+# rtmp port (for rtp and app)
 VIDEO_PORT_RTMP=9005
 
-# 前端和App对讲&flv的https端口，目前使用5个端口, 大于支持30个通道
-# 增加端口需要修改nginx的config和docker-compose.yml以及rtp服务映射
-VIDEO_PORT_HTTPS_0=9084 # 推荐443或者9084
+# HTTPS ports for frontend and App intercom & flv, currently using 5 ports, supports more than 30 channels
+# To add ports, need to modify nginx config, docker-compose.yml, and rtp service mapping
+VIDEO_PORT_HTTPS_0=9084 # Recommend 443 or 9084
 VIDEO_PORT_HTTPS_1=9085
 VIDEO_PORT_HTTPS_2=9086
 VIDEO_PORT_HTTPS_3=9087
 VIDEO_PORT_HTTPS_4=9088
 VIDEO_PORT_HTTPS_5=9089
 
-## 网关服务器
-# 必填, 后端和流媒体服务往网关服务器注册或者下发指令
+## Gateway Server
+# Required, backend and streaming services register or send commands to gateway server
 JTT808_HOST='jtt808'
-JTT808_IP=${SERVER_IP_PUBLIC} # 默认使用服务器公网IP,设备使用
+JTT808_IP=${SERVER_IP_PUBLIC} # Default uses server public IP, for device use
 JTT808_PORT=9011
 JTT808_PORT_HTTP=9012
 JTT808_PORT_FILE=9013
@@ -119,62 +119,62 @@ MAINTAIN_PORT='8080'
 MYSQL_HOST='mysql8'
 MYSQL_PORT=3306
 MYSQL_USERNAME='root'
-MYSQL_PASSWORD='' # 必填
+MYSQL_PASSWORD='' # Required
 
 ## REDIS
 REDIS_HOST='redis'
 REDIS_PORT=6379
-REDIS_PASSWORD='' # 必填
+REDIS_PASSWORD='' # Required
 
 ## MongoDB
 MONGODB_HOST='mongodb'
 MONGODB_PORT=27017
 MONGODB_PORT_HTTP=15672
 MONGODB_USERNAME='root'
-MONGODB_PASSWORD='' # 必填
+MONGODB_PASSWORD='' # Required
 
 ## Rabbitmq
 RABBITMQ_HOST='rabbitmq'
 RABBITMQ_PORT=5672
 RABBITMQ_USERNAME='admin'
-RABBITMQ_PASSWORD='' # 必填
+RABBITMQ_PASSWORD='' # Required
 
 ## Minio
 MINIO_HOST='minio'
 MINIO_PORT=8000
 MINIO_PORT_HTTP=8001
 MINIO_USER=minioadmin
-MINIO_PASSWORD='' # 必填
-# MINIO_ACCESSKEY/SECRETKEY, 默认使用帐号&密码, 也可以在minio的管理后台创建一组新的KEY
+MINIO_PASSWORD='' # Required
+# MINIO_ACCESSKEY/SECRETKEY, default uses account & password, can also create a new KEY in minio admin console
 MINIO_ACCESSKEY=${MINIO_USER}
 MINIO_SECRETKEY=${MINIO_PASSWORD}
-# MINIO ftp功能
+# MINIO ftp functionality
 MINIO_FTP_PORT=8021
 MINIO_FTP_PASSIVE_PORT=8523-8529
 
-## 邮件
-# 默认使用transcodegroup的邮箱
+## Email
+# Default uses transcodegroup email
 MAIL_HOST=smtp.transcodegroup.com
 MAIL_USERNAME=bus@transcodegroup.com
-# 必填, 需要去企业邮箱中创建密码
+# Required, need to create password in enterprise email
 MAIL_PASSWORD=''
 
-## ================================ 版本号, 设为latest则使用最新版 ================================
+## ================================ Version Numbers, set to latest to use latest version ================================
 
-# bus, 版本号核对日期: 2025-12-23
-# bus前端
+# bus, version verification date: 2025-12-23
+# bus frontend
 BUS_WEB_VERSION=5.32.0
-# bus的后端
+# bus backend
 BUS_GATEWAY_VERSION=1.24.0
-# 公交808-2019版本号
+# bus 808-2019 version
 BUS_GATEWAY_808_2019_VERSION=25.8.25
-# 公交主动安全版本号
+# bus active safety version
 BUS_GATEWAY_JSATL12_VERSION=23.1.21
 
-# track, 版本号核对日期: 2025-12-01
-# track前端
+# track, version verification date: 2025-12-01
+# track frontend
 TRACK_WEB_VERSION=1.60.1
-# track后端
+# track backend
 TRACK_MAINTAIN_VERSION=1.54.0
-# track网关
+# track gateway
 TRACK_JTT808_VERSION=1.24.1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # docker
 
-docker配置文件仓库
+Docker configuration files repository
 
-## 部署
+## Deployment
 
-### 1. 初始化
+### 1. Initialization
 
 ```sh
 mkdir -p /home/docker-compose
@@ -12,91 +12,92 @@ mkdir /data
 git clone https://github.com/TranscodeGroup/docker.git /home/docker
 ```
 
-### 2. 配置`compse.yaml`
+### 2. Configure `compose.yaml`
 
-创建`/home/docker-compose/compose.yaml`文件, 参考如下示例:
+Create `/home/docker-compose/compose.yaml` file, refer to the following examples:
 
-**单机单独部署**:
+**Standalone Deployment**:
 
-- [bus-http](./examples/bus-http/compose.yaml): Bus http单机部署
-- [bus-https](./examples/bus-https/compose.yaml): Bus https单机部署
-- [track-http](./examples/track-http/compose.yaml): Tracker V2 http单机部署
-- [track-https](./examples/track-https/compose.yaml): Tracker V2 https单机部署
+- [bus-http](./examples/bus-http/compose.yaml): Bus HTTP standalone deployment
+- [bus-https](./examples/bus-https/compose.yaml): Bus HTTPS standalone deployment
+- [track-http](./examples/track-http/compose.yaml): Tracker V2 HTTP standalone deployment
+- [track-https](./examples/track-https/compose.yaml): Tracker V2 HTTPS standalone deployment
 
-**分布式部署**:
+**Distributed Deployment**:
 
-- [video-storage](./examples/video-storage/compose.yaml): RTP存储
-- [video-stream](./examples/video-stream/compose.yaml): RTP视频
+- [video-storage](./examples/video-storage/compose.yaml): RTP storage
+- [video-stream](./examples/video-stream/compose.yaml): RTP video
 
-### 3. 配置`.env`
+### 3. Configure `.env`
 
-创建`/home/docker-compose/.env`文件, 参考[.env.default](./.env.default)复写需要改写的配置项.
+Create `/home/docker-compose/.env` file, refer to [.env.default](./.env.default) to override configuration items as needed.
 
-在`/home/docker-compose`中执行如下命令, 校验所有使用到的必填的值, 是否已经设置:
+Execute the following command in `/home/docker-compose` to verify all required values have been set:
 
 ```sh
 docker compose config
 ```
 
-校验通过之后, 执行如下命令, 将compose配置导出成一个文件, 方便在更新compose文件后对比差异:
+After validation passes, execute the following command to export the compose configuration to a file, making it easier to compare differences after updating compose files:
 
 ```sh
 docker compose config > compose-stack.yaml
 ```
 
-### 4. 配置前端
+### 4. Configure Frontend
 
-前端复写目录, 用来放`_app.config.js`等项目特定的前端配置文件:
+Frontend override directories, used to place project-specific frontend configuration files such as `_app.config.js`:
 
-- `/home/docker-compose/bus-override`: bus前端复写目录
-- `/home/docker-compose/track-override`: track前端复写目录
+- `/home/docker-compose/bus-override`: Bus frontend override directory
+- `/home/docker-compose/track-override`: Track frontend override directory
 
-**注意**: 修改完配置后, 需要执行`docker compose up`, 文件才会被覆盖到`/data/nginx/html/`里面去. 因为是使用的覆盖的方式, 因此不建议直接修改`/data/nginx/html/`里面的文件.
+**Note**: After modifying configurations, you need to execute `docker compose up` for the files to be copied to `/data/nginx/html/`. Since files are overwritten, it is not recommended to directly modify files in `/data/nginx/html/`.
 
-### 5. 其他可选配置
+### 5. Other Optional Configurations
 
-- [jtt808视频转换工具](./jtt808/README.md)
-- [手动下载前端](./scripts/README.md)
+- [jtt808 Video Conversion Tool](./jtt808/README.md)
+- [Manual Frontend Download](./scripts/README.md)
 
-### 6. 启动
+### 6. Start
 
-在`/home/docker-compose`中执行如下命令, 启动docker:
+Execute the following command in `/home/docker-compose` to start docker:
 
 ```sh
 docker compose up
 ```
 
-### 7. 使用git管理docker-compose目录
+### 7. Use git to Manage docker-compose Directory
 
-在`/home/docker-compose`中执行如下命令
+Execute the following commands in `/home/docker-compose`:
 
 ```sh
-# 切换到目录下面
-cd /home/docker-compose 
+# Change to the directory
+cd /home/docker-compose
 
-# 每次修改配置之后, 记得备份一下配置, 方便对比实际影响差异
+# After each configuration change, remember to backup the configuration for easy comparison of actual differences
 docker compose config > compose-stack.yaml
 
-# 配置GIT账号
+# Configure GIT account
 git config --global user.name "tg"
 git config --global user.email tg@gmail.com
 
-# 初始化GIT
+# Initialize GIT
 git init
-# 加入暂存区
+# Add to staging area
 git add -A
-# 提交本地仓库
-git commit -m "Initial commit(初始化仓库)"
+# Commit to local repository
+git commit -m "Initial commit"
 ```
 
-## 注意事项
+## Important Notes
 
-### 版本管理, 版本迭代同时, 记得同步mysql下面的脚本
+### Version Management
+When updating versions, remember to synchronize the scripts under mysql:
 
 ```sh
-# bus前端
+# Bus frontend
 BUS_WEB_VERSION=xxx
-# bus的后端
+# Bus backend
 BUS_GATEWAY_VERSION=xxx
 #...
 ```

--- a/examples/bus-http/.env
+++ b/examples/bus-http/.env
@@ -1,21 +1,21 @@
-#---------服务器信息, 必须按实际服务器信息填写-----------------
-## HOSTNAME 没有用公网IP替代
+#---------Server Information, must be filled in according to actual server information-----------------
+## HOSTNAME use domain name instead of public IP
 SERVER_HOSTNAME='transcodegroup.cn'
-## 公网IP
+## Public IP
 SERVER_IP_PUBLIC='81.71.36.80'
-# 即使不使用https, 也要配置一个占位证书
+# Even if not using https, must configure a placeholder certificate
 SSL_CERTIFICATE=/home/docker/nginx/ssl/placeholder
 
-#---------自定义初始密码, 建议随机生成新的替换-------------
-## MYSQL, 必填，示例: p92oVkNxrUttUUu8qyqs
+#---------Custom Initial Passwords, recommend generating new random passwords to replace-------------
+## MYSQL, required, example: p92oVkNxrUttUUu8qyqs
 MYSQL_PASSWORD='p92oVkNxrUttUUu8qyqs'
-## redis初始密码, 示例: nse3fLtG4Bm53URq4Ex
+## redis initial password, example: nse3fLtG4Bm53URq4Ex
 REDIS_PASSWORD='p92oVkNxrUttUUu8qyqs'
-## rabbitMq初始密码, 示例: Prr1139gdGhMJ4RDo7Gt
+## rabbitMq initial password, example: Prr1139gdGhMJ4RDo7Gt
 RABBITMQ_PASSWORD='p92oVkNxrUttUUu8qyqs'
-## Email密码, 示例ZfJwfEJvL8wbPr4LvCyx
+## Email password, example ZfJwfEJvL8wbPr4LvCyx
 MAIL_PASSWORD='p92oVkNxrUttUUu8qyqs'
 
-#----------自定义端口信息, 推荐开放9000~9100,443,80--------
-# nginx前端配置
+#----------Custom Port Information, recommend opening 9000~9100,443,80--------
+# nginx frontend configuration
 WEB_PORT_HTTP=9080

--- a/examples/bus-http/compose.yaml
+++ b/examples/bus-http/compose.yaml
@@ -1,11 +1,11 @@
-# Bus单机部署, 使用http
+# Bus standalone deployment, using http
 include:
   - ../docker/mysql8/compose.yml
   - ../docker/mysql-backup/compose.cbus.yml
   - ../docker/rabbitmq/compose.yml
   - ../docker/redis/compose.yml
   - ../docker/bus/compose.yml
-  - path:  
+  - path:
     - ../docker/video/compose.yml
     - ../docker/video/compose.bus.yml
     - ../docker/video/compose.bus.http.yml

--- a/examples/bus-https/.env
+++ b/examples/bus-https/.env
@@ -1,24 +1,24 @@
-##---------服务器信息, 必须按实际服务器信息填写-----------------
-# 公网IP
+##---------Server Information, must be filled in according to actual server information-----------------
+# Public IP
 SERVER_IP_PUBLIC='81.71.36.80'
-# HOSTNAME 没有用域名IP替代
+# HOSTNAME use domain name instead of IP
 SERVER_HOSTNAME='transcodegroup.cn'
-# 自动申请的SSL证书
+# Auto-applied SSL certificate
 SSL_CERTIFICATE="/data/certbot/live/${SERVER_HOSTNAME}/certificate"
-# dnspod的api key, 由id和token拼接而成: https://console.dnspod.cn/account/token/token
+# dnspod api key, formed by concatenating id and token: https://console.dnspod.cn/account/token/token
 CERTBOT_DNS_API_KEY='id,token'
 
-##---------自定义初始密码, 建议随机生成新的替换-------------
-# MYSQL, 必填
+##---------Custom Initial Passwords, recommend generating new random passwords to replace-------------
+# MYSQL, required
 MYSQL_PASSWORD='ZfJwfEJvL8wbPr4LvCyx'
-# REDIS, 必填
+# REDIS, required
 REDIS_PASSWORD='ZfJwfEJvL8wbPr4LvCyx'
-# RABBIT_MQ, 必填
+# RABBIT_MQ, required
 RABBITMQ_PASSWORD='ZfJwfEJvL8wbPr4LvCyx'
-# Email，必填
+# Email, required
 MAIL_PASSWORD='ZfJwfEJvL8wbPr4LvCyx'
 
-##----------自定义端口信息, 推荐开放9000~9100,443,80--------
-# 前端端口配置, HTTP默认80， HTTPS默认443
+##----------Custom Port Information, recommend opening 9000~9100,443,80--------
+# Frontend port configuration, HTTP default 80, HTTPS default 443
 WEB_PORT_HTTP=9070
 WEB_PORT_HTTPS=9080

--- a/examples/bus-https/compose.yaml
+++ b/examples/bus-https/compose.yaml
@@ -1,5 +1,5 @@
-# Bus单机部署, 使用https
-# 密码/端口/域名等信息在.env文件中配置
+# Bus standalone deployment, using https
+# Passwords/ports/domain names etc. are configured in .env file
 include:
   - ../docker/mysql8/compose.yml
   - ../docker/mysql-backup/compose.cbus.yml

--- a/examples/track-http/.env
+++ b/examples/track-http/.env
@@ -1,6 +1,6 @@
 SERVER_IP_PUBLIC='58.82.168.197'
 SERVER_HOSTNAME='th-track.transcodegroup.cn'
-# 即使不使用https, 也要配置一个占位证书
+# Even if not using https, must configure a placeholder certificate
 SSL_CERTIFICATE=/home/docker/nginx/ssl/placeholder
 WEB_PORT_HTTP=80
 

--- a/examples/track-http/compose.yaml
+++ b/examples/track-http/compose.yaml
@@ -1,4 +1,4 @@
-## V2单机部署方案, 使用http
+## V2 standalone deployment solution, using http
 include:
   - ../docker/mysql8/compose.yml
   - ../docker/mysql-backup/compose.maintain.yml

--- a/examples/track-https/.env
+++ b/examples/track-https/.env
@@ -1,6 +1,6 @@
 SERVER_HOSTNAME='vpn.transbustransportes.com.br'
 SERVER_IP_PUBLIC='200.155.137.26'
-# 证书可以先设成placeholder, 保证compose启动起来, 申请到证书之后, 再改成实际的证书路径
+# Certificate can be set to placeholder first to ensure compose starts, after obtaining certificate, change to actual certificate path
 SSL_CERTIFICATE=/home/docker/nginx/ssl/placeholder
 # SSL_CERTIFICATE=/home/docker-compose/ssl/certificate
 

--- a/examples/track-https/compose.yaml
+++ b/examples/track-https/compose.yaml
@@ -1,6 +1,6 @@
-## V2单机部署方案
-# 1. 修改.env文件. 初始化各种密码
-# 2. docker compose up -d启动服务
+## V2 standalone deployment solution
+# 1. Modify .env file, initialize various passwords
+# 2. docker compose up -d to start services
 include:
   - ../docker/mysql8/compose.yml
   - ../docker/redis/compose.yml

--- a/examples/video-storage/.env
+++ b/examples/video-storage/.env
@@ -1,10 +1,10 @@
-## 视频服务器
+## Video Server
 SERVER_IP_PUBLIC=58.82.168.181
 SERVER_HOSTNAME=livedvr.tripsdd.com
-# 证书文件的绝对路径, 排除.crt/.key后缀, nginx使用的是 $VIDEO_SSL_CERTIFICATE.crt 和 $VIDEO_SSL_CERTIFICATE.key 两个文件
+# Absolute path of certificate file, excluding .crt/.key suffix, nginx uses $VIDEO_SSL_CERTIFICATE.crt and $VIDEO_SSL_CERTIFICATE.key files
 SSL_CERTIFICATE=/home/docker/nginx/ssl/placeholder
 
-## 网关服务器
+## Gateway Server
 JTT808_HOST=103.20.204.149
 
 # RABBITMQ

--- a/examples/video-storage/compose.yaml
+++ b/examples/video-storage/compose.yaml
@@ -1,8 +1,8 @@
-## video服务示例
-# 将需要的compose文件全部include进来就行
-# 推荐客户开放连续段端口9000-9100
-# 默认开放端口: 直播9000,录像9001,对接9002, 监听9003,广播9004,RTMP9005:1935(srs)
-# Nginx代理9085-9089: http-flv(srs:8080端口), wss(rtp:9006端口), 拦截mdvr和ws关键字
+## Video service example
+# Just include all required compose files
+# Recommend customers open consecutive port range 9000-9100
+# Default open ports: live 9000, recording 9001, intercom 9002, monitoring 9003, broadcast 9004, RTMP 9005:1935 (srs)
+# Nginx proxy 9085-9089: http-flv (srs:8080 port), wss (rtp:9006 port), intercept mdvr and ws keywords
 include:
   - ../docker/minio/compose.yml
   - path:

--- a/examples/video-stream/.env
+++ b/examples/video-stream/.env
@@ -1,8 +1,8 @@
-## 视频服务器
+## Video Server
 SERVER_IP_PUBLIC=58.82.168.181
 SERVER_HOSTNAME=livedvr.tripsdd.com
-# 证书文件的绝对路径, 排除.crt/.key后缀, nginx使用的是 $VIDEO_SSL_CERTIFICATE.crt 和 $VIDEO_SSL_CERTIFICATE.key 两个文件
+# Absolute path of certificate file, excluding .crt/.key suffix, nginx uses $VIDEO_SSL_CERTIFICATE.crt and $VIDEO_SSL_CERTIFICATE.key files
 SSL_CERTIFICATE=/home/docker/nginx/ssl/placeholder
 
-## 网关服务器
+## Gateway Server
 JTT808_HOST=103.20.204.149

--- a/examples/video-stream/compose.yaml
+++ b/examples/video-stream/compose.yaml
@@ -1,8 +1,8 @@
-## video服务示例
-# 将需要的compose文件全部include进来就行
-# 推荐客户开放连续段端口9000-9100
-# 默认开放端口: 直播9000,录像9001,对接9002, 监听9003,广播9004,RTMP9005:1935(srs)
-# Nginx代理9085-9089: http-flv(srs:8080端口), wss(rtp:9006端口), 拦截mdvr和ws关键字
+## Video service example
+# Just include all required compose files
+# Recommend customers open consecutive port range 9000-9100
+# Default open ports: live 9000, recording 9001, intercom 9002, monitoring 9003, broadcast 9004, RTMP 9005:1935 (srs)
+# Nginx proxy 9085-9089: http-flv (srs:8080 port), wss (rtp:9006 port), intercept mdvr and ws keywords
 include:
   - path:
     - ../docker/nginx/compose.yml

--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -1,38 +1,38 @@
-## FFmpeg 静态编译安装
+## FFmpeg Static Build Installation
 
 ```bash
-# 创建工具文件夹
+# Create tools directory
 mkdir -p /home/docker-compose/opt
-# 进入目录
+# Enter directory
 cd /home/docker-compose/opt
-# 下载
+# Download
 wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-# 解压
+# Extract
 tar -xvf ffmpeg-release-amd64-static.tar.xz
-# 复制bin文件
+# Copy bin files
 cp ./ffmpeg-*-amd64-static/ffmpeg ./ffmpeg-*-amd64-static/ffprobe /home/docker-compose/opt/
-# 测试
+# Test
 ./ffmpeg -version
 ```
 
-## 通力ifv转mp4工具(现在H264正常, H265前端播放器不支持)
+## Tongli IFV to MP4 Conversion Tool (H264 works normally, H265 is not supported by frontend player yet)
 
 ```bash
-# 创建工具文件夹
+# Create tools directory
 mkdir -p /home/docker-compose/opt/ifv2mp4
-# 进入目录
+# Enter directory
 cd /home/docker-compose/opt/ifv2mp4
-# 下载安装程序
+# Download installation program
 wget https://github.com/TranscodeGroup/docker/releases/download/v1.0.2/tlgrectomp4_linux1.0.0.2.tar.gz
-# 解压
+# Extract
 tar -xzvf tlgrectomp4_linux1.0.0.2.tar.gz
-# 增加路径
+# Add path
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/docker-compose/opt/ifv2mp4/release
-# 验证
+# Verify
 /home/docker-compose/opt/ifv2mp4/release/tlgrectomp4 --help
 ```
 
-## 确保jtt808的docker服务包含如下配置(当前版本已内置, 旧版手工补齐)
+## Ensure jtt808 Docker Service Includes the Following Configuration (built-in in current version, manual addition required for older versions)
 
 ```bash
   jtt808:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,8 @@
-# 自动化脚本
+# Automation Scripts
 
-## 手动下载前端: `teamcity-download-artifact.sh`
+## Manual Frontend Download: `teamcity-download-artifact.sh`
 
-下载并提取最新的`bus`前端:
+Download and extract the latest `bus` frontend:
 
 ```sh
 cd /data/nginx/html
@@ -11,7 +11,7 @@ unzip CityBusVueAdmin_Release-latest.zip
 unzip bus.zip -d bus
 ```
 
-下载并提取最新的`track`前端:
+Download and extract the latest `track` frontend:
 
 ```sh
 cd /data/nginx/html
@@ -20,18 +20,18 @@ unzip MaintainVbenAdmin_Release-latest.zip
 unzip maintain.zip -d track
 ```
 
-## 部署distar前端: `distar-beta-deploy.sh`
+## Deploy Distar Frontend: `distar-beta-deploy.sh`
 
 ```sh
-# 确认https://github.com/TranscodeGroup/maintain-vben-admin仓库存在对应的版本tag
-# 确认 http://th-ci.transcodegroup.cn:9080/buildConfiguration/MaintainVbenAdmin_Release 已经打包出附件
+# Confirm that the corresponding version tag exists in https://github.com/TranscodeGroup/maintain-vben-admin repository
+# Confirm that http://th-ci.transcodegroup.cn:9080/buildConfiguration/MaintainVbenAdmin_Release has built the attachment
 
-# 下载tag版本到默认目录, 并解压到版本对应的文件夹
+# Download tag version to default directory and extract to version-corresponding folder
 /home/docker/scripts/distar-beta-deploy.sh --tag=v1.15.1
 
-# 下载tag版本到当前目录
+# Download tag version to current directory
 /home/docker/scripts/distar-beta-deploy.sh --tag=v1.15.1 --dir=.
 
-# 下载tag版本到/data/nginx/html目录
+# Download tag version to /data/nginx/html directory
 /home/docker/scripts/distar-beta-deploy.sh --tag=v1.15.1 --dir=/data/nginx/html
 ```


### PR DESCRIPTION
- 翻译 .md 文件 (README.md, jtt808/README.md, scripts/README.md)
- 翻译 .env.default 环境变量配置文件
- 翻译 examples 目录下的所有 .env 文件 (6个)
- 翻译 examples 目录下的所有 compose.yaml 文件 (6个)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>