### PR TITLE
fix(nginx): 请求的端口未转发到后端, 导致App报1003错误的问题

### DIFF
--- a/nginx/compose.yml
+++ b/nginx/compose.yml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: nginx:1.27.4
+    image: nginx:1.30.2
     restart: always
     ports:
       - ${WEB_PORT_HTTPS:-443}:443

--- a/nginx/conf/conf.d/track.conf.template
+++ b/nginx/conf/conf.d/track.conf.template
@@ -76,6 +76,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $request_port;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
     }
@@ -86,6 +87,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $request_port;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
     }


### PR DESCRIPTION
1. 转发协议之后, Spring同时会设置端口, 若不转发请求端口, 会变成协议的默认端口, 导致后端接收到请求的端口和App发送请求的端口不一致，详见：RemoteIpValve类

2. request_port为1.29.3新增变量, 故升级nginx成最新稳定版 https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_port