### PR TITLE
fix(ffmpeg): 增加8.1.的下载地址, 修复ts文件在新的jdk17镜像下转码失败的BUG

### DIFF
--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -6,14 +6,11 @@ mkdir -p /home/docker-compose/opt
 # Enter directory
 cd /home/docker-compose/opt
 # Download
-# 旧版7x(废弃)
-wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-# 新版8.1
 wget https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Decompress
-tar -xvf ffmpeg-release-amd64-static.tar.xz
+tar -xvf ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Copy bin files
-cp ./ffmpeg-*-amd64-static/ffmpeg ./ffmpeg-*-amd64-static/ffprobe /home/docker-compose/opt/
+cp ./ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1/bin/ffmpeg ./ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1/bin/ffprobe /home/docker-compose/opt/
 # Test
 ./ffmpeg -version
 ```

--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -6,7 +6,7 @@ mkdir -p /home/docker-compose/opt
 # Enter directory
 cd /home/docker-compose/opt
 # Download
-wget https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
+wget https://github.com/TranscodeGroup/docker/releases/download/v1.0.7/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Decompress
 tar -xvf ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Copy bin files

--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -5,8 +5,7 @@
 mkdir -p /home/docker-compose/opt
 # Enter directory
 cd /home/docker-compose/opt
-# Download
-# 源地址：https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
+# Download (source: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz)
 wget https://github.com/TranscodeGroup/docker/releases/download/v1.0.7/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Decompress
 tar -xvf ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz

--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -6,6 +6,7 @@ mkdir -p /home/docker-compose/opt
 # Enter directory
 cd /home/docker-compose/opt
 # Download
+# 源地址：https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 wget https://github.com/TranscodeGroup/docker/releases/download/v1.0.7/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Decompress
 tar -xvf ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz

--- a/jtt808/README.md
+++ b/jtt808/README.md
@@ -6,7 +6,10 @@ mkdir -p /home/docker-compose/opt
 # Enter directory
 cd /home/docker-compose/opt
 # Download
+# 旧版7x(废弃)
 wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+# 新版8.1
+wget https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-14-13-33/ffmpeg-n8.1.1-117-g7aecd49777-linux64-gpl-8.1.tar.xz
 # Decompress
 tar -xvf ffmpeg-release-amd64-static.tar.xz
 # Copy bin files


### PR DESCRIPTION
可能是因为jdk17依赖了最新的Ubuntu系统版本, jimi的ts文件, 在宿主机转码成功，在docker镜像内提示Segmentation fault (core dumped), 所以更新到8x版本